### PR TITLE
Use the play2-memcached logger rather than global one

### DIFF
--- a/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
+++ b/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
@@ -73,11 +73,11 @@ class MemcachedPlugin(app: Application) extends CachePlugin {
   lazy val api = new CacheAPI {
 
     def get(key: String) = {
-      Logger.info("Getting the cached for key " + key)
+      logger.info("Getting the cached for key " + key)
       val future = client.asyncGet(key, tc)
       catching[Any](classOf[Exception]) opt {
         val any = future.get(1, TimeUnit.SECONDS)
-        Logger.info("any is " + any.getClass)
+        logger.info("any is " + any.getClass)
         any match {
           case x: java.lang.Byte => x.byteValue()
           case x: java.lang.Short => x.shortValue()


### PR DESCRIPTION
Thanks for releasing play2-memcached to the public.  It really is great.  I am new to this but getting a bunch of info messages in my log I don't expect and I can't figure out how to shut them off.  I believe this is the right fix.
