### PR TITLE
It makes memcached plugin to be enable to use namespace

### DIFF
--- a/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
+++ b/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
@@ -97,8 +97,8 @@ class MemcachedPlugin(app: Application) extends CachePlugin {
   lazy val api = new CacheAPI {
 
     def get(key: String) = {
-      logger.debug("Getting the cached for key " + key)
-      val future = client.asyncGet(key, tc)
+      logger.debug("Getting the cached for key " + namespace + key)
+      val future = client.asyncGet(namespace + key, tc)
       try {
         val any = future.get(1, TimeUnit.SECONDS)
         if (any != null) {
@@ -126,13 +126,15 @@ class MemcachedPlugin(app: Application) extends CachePlugin {
     }
 
     def set(key: String, value: Any, expiration: Int) {
-      client.set(key, expiration, value, tc)
+      client.set(namespace + key, expiration, value, tc)
     }
 
     def remove(key: String) {
-      client.delete(key)
+      client.delete(namespace + key)
     }
   }
+  
+  lazy val namespace: String = app.configuration.getString("memcached.namespace").getOrElse("")
 
   /**
    * Is this plugin enabled.


### PR DESCRIPTION
I want to use this memcached plugin in multiple play applications.
But my environment has only one memcached daemon.
So, I use namespace in each play applications

ex) application.conf

```
memcached.host="127.0.0.1:11211"
memcached.namespace="MyApplication"
```
