### PR TITLE
Spymemcached 2.8.10+ Has SASL Bugs That Prevent Auth To Popular Memcache...

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -29,7 +29,7 @@ object ApplicationBuild extends Build {
     .settings(
       resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
       resolvers += "Spy Repository" at "http://files.couchbase.com/maven2",
-      libraryDependencies += "spy" % "spymemcached" % "2.8.12",
+      libraryDependencies += "spy" % "spymemcached" % "2.8.9",
       libraryDependencies += "play" %% "play" % "2.1.0" % "provided",
       organization := "com.github.mumoshu",
       version := appVersion,


### PR DESCRIPTION
...d Providers. Reverting to 2.8.9
- https://code.google.com/p/spymemcached/issues/detail?id=272
- Issue also affects memcachier (used with Heroku, Cloudbees, other popular PaaS providers).
