### PR TITLE
Adding configurable timeouts on the future

### DIFF
--- a/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
+++ b/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
@@ -103,7 +103,7 @@ class MemcachedPlugin(app: Application) extends CachePlugin {
       logger.debug("Getting the cached for key " + namespace + key)
       val future = client.asyncGet(namespace + key, tc)
       try {
-        val any = future.get(1, TimeUnit.SECONDS)
+        val any = future.get(timeout, timeunit)
         if (any != null) {
           logger.debug("any is " + any.getClass)
         }
@@ -138,6 +138,19 @@ class MemcachedPlugin(app: Application) extends CachePlugin {
   }
   
   lazy val namespace: String = app.configuration.getString("memcached.namespace").getOrElse("")
+
+  lazy val timeout: Int = app.configuration.getInt("memcached.timeout").getOrElse(1)
+
+  lazy val timeunit: TimeUnit = {
+    app.configuration.getString("memcached.timeunit").getOrElse("seconds") match {
+      case "seconds" => TimeUnit.SECONDS
+      case "milliseconds" => TimeUnit.MILLISECONDS 
+      case "microseconds" => TimeUnit.MICROSECONDS
+      case "nanoseconds" => TimeUnit.NANOSECONDS
+      case _ => TimeUnit.SECONDS
+    }
+  }
+
 
   /**
    * Is this plugin enabled.


### PR DESCRIPTION
In the scenario your memcached server is offline, then every single call takes one second before it fails and reports back to Play that the item is not in cache. If you have many cached items that must be retrieved to give a single response to a user, then having an outage on your memcached server becomes completely unacceptable.

In reality, most things that you cache in memcached could likely be fetched or recomposed directly from the master source in much less time than a second. This enhancement allows you to configure both the timeout duration and the timeout unit. If the properties are not specified in configuration, then the library will continue to function as before with a one second timeout.
