### PR TITLE
Empty keys - kind of ehcache compilance, avoiding IllegalArgumentExceptions

### DIFF
--- a/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
+++ b/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
@@ -132,11 +132,15 @@ class MemcachedPlugin(app: Application) extends CachePlugin {
     }
 
     def set(key: String, value: Any, expiration: Int) {
-      client.set(namespace + key, expiration, value, tc)
+      if (!key.isEmpty) {
+        client.set(namespace + key, expiration, value, tc)
+      }
     }
 
     def remove(key: String) {
-      client.delete(namespace + key)
+      if (!key.isEmpty) {
+        client.delete(namespace + key)
+      }
     }
   }
   

--- a/samples/scala/test/EhcachePluginComplianceSpec.scala
+++ b/samples/scala/test/EhcachePluginComplianceSpec.scala
@@ -98,6 +98,14 @@ object EhcachePluginComplianceSpec extends ServerIntegrationSpec {
 
       ehcache.get(key) must be equalTo (Some(null))
     }
+
+    "store value for empty key" in new cacheImpls {
+      ehcache.set("", "aa", 0)
+      ehcache.get("") must be some ("aa")
+
+      ehcache.remove("")
+      ehcache.get("") must be none
+    }
   }
 
   "Memcached implementation of CacheAPI" should {
@@ -113,6 +121,14 @@ object EhcachePluginComplianceSpec extends ServerIntegrationSpec {
       memcache.set(key, null, 0)
 
       memcache.get(key) must be none
+    }
+
+    "not store value for empty key" in new cacheImpls {
+      memcache.set("", "aa", 0)
+      memcache.get("") must be none
+
+      memcache.remove("")
+      memcache.get("") must be none
     }
   }
 


### PR DESCRIPTION
Currently when you try to obtain/set/remove cached value for an empty key you will get following exception:

```
IllegalArgumentException: Key must contain at least one character. (StringUtils.java:73)
   net.spy.memcached.util.StringUtils.validateKey(StringUtils.java:73)
   net.spy.memcached.MemcachedConnection.enqueueOperation(MemcachedConnection.java:640)
   net.spy.memcached.MemcachedClient.asyncGet(MemcachedClient.java:847)
   com.github.mumoshu.play2.memcached.MemcachedPlugin$$anon$2.get(MemcachedPlugin.scala:104)
   (..)
```

I discover that some plugins (for example SecureSocial) which uses CacheAPI seems to be not tested with other implementation than default (Ehcache).

In my opinion it will be better to ignore empty keys and avoid exception.
I'm aware that since CacheAPI does not establish any kind of 'cache keys contract' it is hard to determine who is responsible for guarding keys (client or concrete cache api implementation?) so do with this pull request what you want ;)
