### PR TITLE
Hash keys before each operation

### DIFF
--- a/samples/java/conf/application.conf
+++ b/samples/java/conf/application.conf
@@ -58,3 +58,7 @@ logger.application=DEBUG
 #ehcacheplugin=disabled
 #memcachedplugin=disabled
 memcached.host="127.0.0.1:11211"
+
+# You may consider activating this option to enable support for long keys (more than 250 characters)
+# Available options are MD2, MD5, SHA-1, SHA-256, SHA-384, SHA-512 (see http://docs.oracle.com/javase/1.4.2/docs/guide/security/CryptoSpec.html#AppA)
+memcached.hashkeys=off

--- a/samples/scala/conf/application.conf
+++ b/samples/scala/conf/application.conf
@@ -52,3 +52,7 @@ logger.memcached=DEBUG
 ehcacheplugin=disabled
 # memcachedplugin=disabled
 memcached.host="127.0.0.1:11211"
+
+# You may consider activating this option to enable support for long keys (more than 250 characters)
+# Available options are MD2, MD5, SHA-1, SHA-256, SHA-384, SHA-512 (see http://docs.oracle.com/javase/1.4.2/docs/guide/security/CryptoSpec.html#AppA)
+memcached.hashkeys=off


### PR DESCRIPTION
My application uses your memcached plugin + securesocial plugin for authentication.
Using both simultaneously causes Exceptions like "key too long (maximum length 250...".
That's why I propose for better compatibility with the rest of the world to hash keys before each operation (or add relevant configuration parameter), since there may be other cases, when 250 bytes is not enough
