### PR TITLE
Exceptions from get

### DIFF
--- a/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
+++ b/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
@@ -125,9 +125,14 @@ class MemcachedPlugin(app: Application) extends CachePlugin {
           )
         } catch {
           case e: Throwable =>
-            logger.error("An error has occured while getting the value from memcached" , e)
             future.cancel(false)
-            None
+            if (app.configuration.getBoolean("memcached.throwExceptionFromGetOnError").getOrElse(false)) {
+              logger.error("An error has occured while getting the value from memcached" , e)
+              None
+            }
+            else {
+              throw e
+            }
         }
     }
 

--- a/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
+++ b/plugin/src/main/scala/com/github/mumoshu/play2/memcached/MemcachedPlugin.scala
@@ -127,11 +127,11 @@ class MemcachedPlugin(app: Application) extends CachePlugin {
           case e: Throwable =>
             future.cancel(false)
             if (app.configuration.getBoolean("memcached.throwExceptionFromGetOnError").getOrElse(false)) {
-              logger.error("An error has occured while getting the value from memcached" , e)
-              None
+              throw e
             }
             else {
-              throw e
+              logger.error("An error has occured while getting the value from memcached" , e)
+              None
             }
         }
     }


### PR DESCRIPTION
Currently, a None from .get means both "cache miss" and "memcached down/connection issues". I'd like to distinguish between these two cases. This code introduces a new config property ("memcached.throwExceptionFromGetOnError") that allows the original Exception escape to the calling code.
