### PR TITLE
Remove global state

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For Play 2.6.x:
 ```scala
   val appDependencies = Seq(
     play.PlayImport.cacheApi,
-    "com.github.mumoshu" %% "play2-memcached-play26" % "0.9.0"
+    "com.github.mumoshu" %% "play2-memcached-play26" % "0.9.1"
   )
   val main = Project(appName).enablePlugins(play.PlayScala).settings(
     version := appVersion,
@@ -320,6 +320,8 @@ Configure your configuration endpoint in `application.conf`:
 
 0.9.0 Built for Play 2.6.x and Scala 2.11.11 and 2.12.3. Artifact ID for this build is `play2-memcached-play26_2.1{1,2}`
   !!! Changed `play.modules.cache.*` config keys to `play.cache.*` !!!
+
+0.9.1 Remove global state by removing reference to deprecated Play.current
 
 ### Publishing to the central
 

--- a/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/CustomSerializing.scala
+++ b/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/CustomSerializing.scala
@@ -1,1 +1,27 @@
-../../../../../../play_2.5/com/github/mumoshu/play2/memcached/CustomSerializing.scala
+package com.github.mumoshu.play2.memcached
+
+import java.io.{ObjectOutputStream, ByteArrayOutputStream, ObjectStreamClass}
+
+import net.spy.memcached.transcoders.SerializingTranscoder
+
+class CustomSerializing extends SerializingTranscoder{
+
+  // You should not catch exceptions and return nulls here,
+  // because you should cancel the future returned by asyncGet() on any exception.
+  override protected def deserialize(data: Array[Byte]): java.lang.Object = {
+    new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(data)) {
+      override protected def resolveClass(desc: ObjectStreamClass) = {
+        Class.forName(desc.getName(), false, play.api.Play.current.classloader)
+      }
+    }.readObject()
+  }
+
+  // We don't catch exceptions here to make it corresponding to `deserialize`.
+  override protected def serialize(obj: java.lang.Object) = {
+    val bos: ByteArrayOutputStream = new ByteArrayOutputStream()
+    // Allows serializing `null`.
+    // See https://github.com/mumoshu/play2-memcached/issues/7
+    new ObjectOutputStream(bos).writeObject(obj)
+    bos.toByteArray()
+  }
+}

--- a/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/CustomSerializing.scala
+++ b/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/CustomSerializing.scala
@@ -4,14 +4,14 @@ import java.io.{ObjectOutputStream, ByteArrayOutputStream, ObjectStreamClass}
 
 import net.spy.memcached.transcoders.SerializingTranscoder
 
-class CustomSerializing extends SerializingTranscoder{
+class CustomSerializing(private val classLoader: ClassLoader) extends SerializingTranscoder{
 
   // You should not catch exceptions and return nulls here,
   // because you should cancel the future returned by asyncGet() on any exception.
   override protected def deserialize(data: Array[Byte]): java.lang.Object = {
     new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(data)) {
       override protected def resolveClass(desc: ObjectStreamClass) = {
-        Class.forName(desc.getName(), false, play.api.Play.current.classloader)
+        Class.forName(desc.getName(), false, classLoader)
       }
     }.readObject()
   }

--- a/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/MemcachedCacheApi.scala
+++ b/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/MemcachedCacheApi.scala
@@ -6,7 +6,7 @@ import net.spy.memcached.transcoders.Transcoder
 import net.spy.memcached.internal.{ GetCompletionListener, GetFuture, OperationCompletionListener, OperationFuture }
 import net.spy.memcached.ops.StatusCode
 import play.api.cache.AsyncCacheApi
-import play.api.{Logger, Configuration}
+import play.api.{Environment, Logger, Configuration}
 
 import javax.inject.{Inject, Singleton}
 
@@ -18,9 +18,9 @@ import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.reflect.ClassTag
 
 @Singleton
-class MemcachedCacheApi @Inject() (val namespace: String, val client: MemcachedClient, configuration: Configuration)(implicit context: ExecutionContext) extends AsyncCacheApi {
+class MemcachedCacheApi @Inject() (val namespace: String, val client: MemcachedClient, configuration: Configuration, environment: Environment)(implicit context: ExecutionContext) extends AsyncCacheApi {
   lazy val logger = Logger("memcached.plugin")
-  lazy val tc = new CustomSerializing().asInstanceOf[Transcoder[Any]]
+  lazy val tc = new CustomSerializing(environment.classLoader).asInstanceOf[Transcoder[Any]]
   lazy val hashkeys: String = configuration.getString("memcached.hashkeys").getOrElse("off")
   lazy val throwExceptionFromGetOnError: Boolean = configuration.getBoolean("memcached.throwExceptionFromGetOnError").getOrElse(false)
 

--- a/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/MemcachedCacheApiProvider.scala
+++ b/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/MemcachedCacheApiProvider.scala
@@ -2,7 +2,7 @@ package com.github.mumoshu.play2.memcached
 
 import akka.actor.ActorSystem
 
-import play.api.Configuration
+import play.api.{Configuration, Environment}
 import play.api.inject.{BindingKey, Injector}
 import play.api.cache.AsyncCacheApi
 
@@ -13,12 +13,12 @@ import net.spy.memcached.MemcachedClient
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class MemcachedCacheApiProvider(namespace: String, client: BindingKey[MemcachedClient], configuration: Configuration) extends Provider[AsyncCacheApi] {
+class MemcachedCacheApiProvider(namespace: String, client: BindingKey[MemcachedClient], configuration: Configuration, environment: Environment) extends Provider[AsyncCacheApi] {
   @Inject private var injector: Injector = _
   @Inject private var actorSystem: ActorSystem = _
   private lazy val ec: ExecutionContext = configuration.get[Option[String]]("play.cache.dispatcher").map(actorSystem.dispatchers.lookup(_)).getOrElse(injector.instanceOf[ExecutionContext])
 
   lazy val get: AsyncCacheApi = {
-    new MemcachedCacheApi(namespace, injector.instanceOf(client), configuration)(ec)
+    new MemcachedCacheApi(namespace, injector.instanceOf(client), configuration, environment)(ec)
   }
 }

--- a/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/MemcachedComponents.java
+++ b/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/MemcachedComponents.java
@@ -1,5 +1,6 @@
 package com.github.mumoshu.play2.memcached;
 
+import play.Environment;
 import play.cache.AsyncCacheApi;
 import play.cache.DefaultAsyncCacheApi;
 import play.components.AkkaComponents;
@@ -37,6 +38,8 @@ import play.inject.ApplicationLifecycle;
  */
 public interface MemcachedComponents extends ConfigurationComponents, AkkaComponents {
 
+    Environment environment();
+
     ApplicationLifecycle applicationLifecycle();
 
     default MemcachedClientProvider memcachedClientProvider() {
@@ -47,7 +50,7 @@ public interface MemcachedComponents extends ConfigurationComponents, AkkaCompon
     }
 
     default AsyncCacheApi cacheApi(String name) {
-        play.api.cache.AsyncCacheApi scalaAsyncCacheApi = new MemcachedCacheApi(name, memcachedClientProvider().get(), configuration(), executionContext());
+        play.api.cache.AsyncCacheApi scalaAsyncCacheApi = new MemcachedCacheApi(name, memcachedClientProvider().get(), configuration(), environment().asScala(), executionContext());
         return new DefaultAsyncCacheApi(scalaAsyncCacheApi);
     }
 

--- a/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/MemcachedModule.scala
+++ b/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/MemcachedModule.scala
@@ -44,7 +44,7 @@ class MemcachedModule extends SimpleModule((environment, configuration) => {
     val namedCache = named(name)
     val cacheApiKey = bind[AsyncCacheApi].qualifiedWith(namedCache)
     Seq(
-      cacheApiKey.to(new MemcachedCacheApiProvider(name, bind[MemcachedClient], configuration))
+      cacheApiKey.to(new MemcachedCacheApiProvider(name, bind[MemcachedClient], configuration, environment))
     ) ++ wrapperBindings(cacheApiKey, namedCache)
   }
 

--- a/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/api/MemcachedComponents.scala
+++ b/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/api/MemcachedComponents.scala
@@ -13,6 +13,7 @@ import scala.concurrent.ExecutionContext
  */
 trait MemcachedComponents {
   def configuration: Configuration
+  def environment: Environment
   def applicationLifecycle: ApplicationLifecycle
   implicit def executionContext: ExecutionContext
 
@@ -22,7 +23,7 @@ trait MemcachedComponents {
    * Use this to create with the given name.
    */
   def cacheApi(name: String, create: Boolean = true): AsyncCacheApi = {
-    new MemcachedCacheApi(name, memcachedClientProvider.get, configuration)
+    new MemcachedCacheApi(name, memcachedClientProvider.get, configuration, environment)
   }
 
   lazy val defaultCacheApi: AsyncCacheApi = cacheApi("play")

--- a/plugin/src/test/play_2.6/MemcachedSpec.scala
+++ b/plugin/src/test/play_2.6/MemcachedSpec.scala
@@ -27,6 +27,7 @@ object MemcachedSpec extends Specification {
       "com.github.mumoshu.play2.memcached.MemcachedModule",
       "play.api.inject.BuiltinModule"
     ).asJava,
+    "play.allowGlobalApplication" -> "false",
     "play.cache.defaultCache" -> "default",
     "play.cache.bindCaches" -> List("secondary").asJava,
     "memcached.1.host" -> memcachedHost

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ import com.typesafe.sbt.pgp.PgpKeys._
 object ApplicationBuild extends Build {
 
   val appName         = "play2-memcached-" + playShortName
-  val appVersion      = "0.9.0"
+  val appVersion      = "0.9.1"
 
   lazy val baseSettings = Seq(
     parallelExecution in Test := false

--- a/samples/java/play_2.6/build.sbt
+++ b/samples/java/play_2.6/build.sbt
@@ -2,5 +2,5 @@ libraryDependencies ++= Seq(
   javaJdbc,
   cacheApi,
   javaWs,
-  "com.github.mumoshu" %% "play2-memcached-play26" % "0.9.0"
+  "com.github.mumoshu" %% "play2-memcached-play26" % "0.9.1"
 )

--- a/samples/java/play_2.6/conf/application.conf
+++ b/samples/java/play_2.6/conf/application.conf
@@ -53,3 +53,5 @@ memcached.host="127.0.0.1:11211"
 # You may consider activating this option to enable support for long keys (more than 250 characters)
 # Available options are MD2, MD5, SHA-1, SHA-256, SHA-384, SHA-512 (see http://docs.oracle.com/javase/1.4.2/docs/guide/security/CryptoSpec.html#AppA)
 memcached.hashkeys=off
+
+play.allowGlobalApplication = false

--- a/samples/scala/play_2.6/app/controllers/Application.scala
+++ b/samples/scala/play_2.6/app/controllers/Application.scala
@@ -6,7 +6,7 @@ import play.api.cache._
 import javax.inject._
 import scala.concurrent.duration._
 
-class Application @Inject() (cache: CacheApi, @NamedCache("session-cache") sessionCache: CacheApi) extends Controller {
+class Application @Inject() (cache: SyncCacheApi, @NamedCache("session-cache") sessionCache: SyncCacheApi, val controllerComponents: ControllerComponents) extends BaseController {
 
   def index = Action {
     Ok(views.html.index("Your new application is ready."))

--- a/samples/scala/play_2.6/built.sbt
+++ b/samples/scala/play_2.6/built.sbt
@@ -2,7 +2,7 @@ libraryDependencies ++= Seq(
   jdbc,
   cacheApi,
   ws,
-  "com.github.mumoshu" %% "play2-memcached-play26" % "0.9.0",
+  "com.github.mumoshu" %% "play2-memcached-play26" % "0.9.1",
   specs2 % Test
 )
 

--- a/samples/scala/play_2.6/conf/application.conf
+++ b/samples/scala/play_2.6/conf/application.conf
@@ -53,3 +53,5 @@ memcached.host="127.0.0.1:11211"
 # You may consider activating this option to enable support for long keys (more than 250 characters)
 # Available options are MD2, MD5, SHA-1, SHA-256, SHA-384, SHA-512 (see http://docs.oracle.com/javase/1.4.2/docs/guide/security/CryptoSpec.html#AppA)
 memcached.hashkeys=off
+
+play.allowGlobalApplication = false


### PR DESCRIPTION
Remove global state by removing a reference to `Play.current` inside `CustomSerializing` (you don't see the old class in the diff because it was a symlink before).
Instead we inject `Environment` and pass its classloader to `CustomSerializing`.
See https://www.playframework.com/documentation/2.6.x/Highlights26#Global-State-Free-Applications

Review is probably done best on per-commit basis so it's easier for your to comprehend my thoughts.

@mumoshu Can you please merge and cut a new release? I prepared everything, it should be easy for you. We really need a new version asap, thanks!