### PR TITLE
Fix frozen future in 2.6 API

### DIFF
--- a/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/MemcachedCacheApi.scala
+++ b/plugin/src/main/play_2.6/com/github/mumoshu/play2/memcached/MemcachedCacheApi.scala
@@ -34,32 +34,36 @@ class MemcachedCacheApi @Inject() (val namespace: String, val client: MemcachedC
       val p = Promise[Option[T]]() // create incomplete promise/future
       client.asyncGet(namespace + hash(key), tc).addListener(new GetCompletionListener() {
         def onComplete(result: GetFuture[_]) {
-          result.getStatus().getStatusCode() match {
-            case StatusCode.SUCCESS => {
-              val any = result.get
-              logger.debug("any is " + any.getClass)
-              p.success(Option(
-                any match {
-                  case x if ct.runtimeClass.isInstance(x) => x.asInstanceOf[T]
-                  case x if ct == ClassTag.Nothing => x.asInstanceOf[T]
-                  case x => x.asInstanceOf[T]
-                }
-              ))
-            }
-            case StatusCode.ERR_NOT_FOUND => {
-              logger.debug("Cache miss for " + namespace + key)
-              p.success(None)
-            }
-            case _ => {
-              val msg = "An error has occured while getting the value from memcached. ct=" + ct + ". key=" + key + ". " +
-                "spymemcached code: " + result.getStatus().getStatusCode() + " memcached code:" + result.getStatus().getMessage()
-              if (throwExceptionFromGetOnError) {
-                p.failure(new RuntimeException(msg))
-              } else {
-                logger.error(msg)
+          try {
+            result.getStatus().getStatusCode() match {
+              case StatusCode.SUCCESS => {
+                val any = result.get
+                logger.debug("any is " + any.getClass)
+                p.success(Option(
+                  any match {
+                    case x if ct.runtimeClass.isInstance(x) => x.asInstanceOf[T]
+                    case x if ct == ClassTag.Nothing => x.asInstanceOf[T]
+                    case x => x.asInstanceOf[T]
+                  }
+                ))
+              }
+              case StatusCode.ERR_NOT_FOUND => {
+                logger.debug("Cache miss for " + namespace + key)
                 p.success(None)
               }
+              case _ => {
+                val msg = "An error has occured while getting the value from memcached. ct=" + ct + ". key=" + key + ". " +
+                  "spymemcached code: " + result.getStatus().getStatusCode() + " memcached code:" + result.getStatus().getMessage()
+                if (throwExceptionFromGetOnError) {
+                  p.failure(new RuntimeException(msg))
+                } else {
+                  logger.error(msg)
+                  p.success(None)
+                }
+              }
             }
+          } catch {
+            case e: Throwable => p.failure(e)
           }
         }
       })


### PR DESCRIPTION
`result.get` can throw an exception in various situations, like if a class definition has changed, and in this case the Promise or the resulting Future was never being completed, causing frozen requests for us when fetching old definitions from cache.

Only affects 2.6 as older code uses `future.get` which _is_ wrapped in a `try/catch`.