### PR TITLE
#48 Add configuration for controlling threshold of memcached timeout …

### DIFF
--- a/plugin/src/main/play_2.5/com/github/mumoshu/play2/memcached/MemcachedClientProvider.scala
+++ b/plugin/src/main/play_2.5/com/github/mumoshu/play2/memcached/MemcachedClientProvider.scala
@@ -42,7 +42,7 @@ class MemcachedClientProvider @Inject() (configuration: Configuration, lifecycle
             new PlainCallbackHandler(memcacheUser, memcachePassword))
           val cf = new ConnectionFactoryBuilder()
             .setProtocol(ConnectionFactoryBuilder.Protocol.BINARY)
-            .setTimeoutExceptionThreshold(configuration.getOptional[Int]("memcached.max-timeout-exception-threshold").getOrElse(DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD))
+            .setTimeoutExceptionThreshold(configuration.getInt("memcached.max-timeout-exception-threshold").getOrElse(DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD))
             .setAuthDescriptor(ad)
             .build()
 

--- a/plugin/src/main/play_2.5/com/github/mumoshu/play2/memcached/MemcachedClientProvider.scala
+++ b/plugin/src/main/play_2.5/com/github/mumoshu/play2/memcached/MemcachedClientProvider.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 
 import javax.inject.{Inject, Singleton, Provider}
 
-import net.spy.memcached.{ConnectionFactoryBuilder, AddrUtil, MemcachedClient}
+import net.spy.memcached.{ConnectionFactoryBuilder, AddrUtil, MemcachedClient, DefaultConnectionFactory}
 
 @Singleton
 class MemcachedClientProvider @Inject() (configuration: Configuration, lifecycle: ApplicationLifecycle) extends Provider[MemcachedClient] {
@@ -42,6 +42,7 @@ class MemcachedClientProvider @Inject() (configuration: Configuration, lifecycle
             new PlainCallbackHandler(memcacheUser, memcachePassword))
           val cf = new ConnectionFactoryBuilder()
             .setProtocol(ConnectionFactoryBuilder.Protocol.BINARY)
+            .setTimeoutExceptionThreshold(configuration.getOptional[Int]("memcached.max-timeout-exception-threshold").getOrElse(DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD))
             .setAuthDescriptor(ad)
             .build()
 


### PR DESCRIPTION
This is necessary especially for auto recover environment of cluster. For example: k8s will recover service in different IP address and service need to recreate socket channel to reconnect to memcached or mcrouter services.