### PR TITLE
Use typesafe Config instead of deprecated play.api.Configuration

### DIFF
--- a/plugin/src/main/com/github/mumoshu/play2/memcached/MemcachedCacheApi.scala
+++ b/plugin/src/main/com/github/mumoshu/play2/memcached/MemcachedCacheApi.scala
@@ -2,11 +2,12 @@ package com.github.mumoshu.play2.memcached
 
 import akka.Done
 
+import com.typesafe.config.Config
 import net.spy.memcached.transcoders.Transcoder
 import net.spy.memcached.internal.{ GetCompletionListener, GetFuture, OperationCompletionListener, OperationFuture }
 import net.spy.memcached.ops.StatusCode
 import play.api.cache.AsyncCacheApi
-import play.api.{Environment, Logger, Configuration}
+import play.api.{Environment, Logger}
 
 import javax.inject.{Inject, Singleton}
 
@@ -18,11 +19,11 @@ import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.reflect.ClassTag
 
 @Singleton
-class MemcachedCacheApi @Inject() (val namespace: String, val client: MemcachedClient, configuration: Configuration, environment: Environment)(implicit context: ExecutionContext) extends AsyncCacheApi {
+class MemcachedCacheApi @Inject() (val namespace: String, val client: MemcachedClient, config: Config, environment: Environment)(implicit context: ExecutionContext) extends AsyncCacheApi {
   lazy val logger = Logger("memcached.plugin")
   lazy val tc = new CustomSerializing(environment.classLoader).asInstanceOf[Transcoder[Any]]
-  lazy val hashkeys: String = configuration.getString("memcached.hashkeys").getOrElse("off")
-  lazy val throwExceptionFromGetOnError: Boolean = configuration.getBoolean("memcached.throwExceptionFromGetOnError").getOrElse(false)
+  lazy val hashkeys: String = config.getString("memcached.hashkeys")
+  lazy val throwExceptionFromGetOnError: Boolean = config.getBoolean("memcached.throwExceptionFromGetOnError")
 
   def get[T: ClassTag](key: String): Future[Option[T]] = {
     if (key.isEmpty) {

--- a/plugin/src/main/com/github/mumoshu/play2/memcached/MemcachedCacheApiProvider.scala
+++ b/plugin/src/main/com/github/mumoshu/play2/memcached/MemcachedCacheApiProvider.scala
@@ -2,7 +2,8 @@ package com.github.mumoshu.play2.memcached
 
 import akka.actor.ActorSystem
 
-import play.api.{Configuration, Environment}
+import com.typesafe.config.Config
+import play.api.Environment
 import play.api.inject.{BindingKey, Injector}
 import play.api.cache.AsyncCacheApi
 
@@ -13,12 +14,20 @@ import net.spy.memcached.MemcachedClient
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class MemcachedCacheApiProvider(namespace: String, client: BindingKey[MemcachedClient], configuration: Configuration, environment: Environment) extends Provider[AsyncCacheApi] {
+class MemcachedCacheApiProvider(namespace: String, client: BindingKey[MemcachedClient], config: Config, environment: Environment) extends Provider[AsyncCacheApi] {
   @Inject private var injector: Injector = _
   @Inject private var actorSystem: ActorSystem = _
-  private lazy val ec: ExecutionContext = configuration.get[Option[String]]("play.cache.dispatcher").map(actorSystem.dispatchers.lookup(_)).getOrElse(injector.instanceOf[ExecutionContext])
+  private lazy val ec: ExecutionContext = if(config.hasPath(MemcachedCacheApiProvider.PLAY_CACHE_DISPATCHER)) {
+    actorSystem.dispatchers.lookup(config.getString(MemcachedCacheApiProvider.PLAY_CACHE_DISPATCHER))
+  } else {
+    injector.instanceOf[ExecutionContext]
+  }
 
   lazy val get: AsyncCacheApi = {
-    new MemcachedCacheApi(namespace, injector.instanceOf(client), configuration, environment)(ec)
+    new MemcachedCacheApi(namespace, injector.instanceOf(client), config, environment)(ec)
   }
+}
+
+object MemcachedCacheApiProvider {
+  final val PLAY_CACHE_DISPATCHER = "play.cache.dispatcher"
 }

--- a/plugin/src/main/com/github/mumoshu/play2/memcached/MemcachedClientProvider.scala
+++ b/plugin/src/main/com/github/mumoshu/play2/memcached/MemcachedClientProvider.scala
@@ -1,8 +1,9 @@
 package com.github.mumoshu.play2.memcached
 
+import com.typesafe.config.Config
 import net.spy.memcached.auth.{PlainCallbackHandler, AuthDescriptor}
-import play.api.{Logger, Configuration, Environment}
-import play.api.inject.{ BindingKey, Injector, ApplicationLifecycle }
+import play.api.Logger
+import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.Future
 
@@ -11,43 +12,62 @@ import javax.inject.{Inject, Singleton, Provider}
 import net.spy.memcached.{KetamaConnectionFactory, ConnectionFactoryBuilder, AddrUtil, MemcachedClient, DefaultConnectionFactory}
 
 @Singleton
-class MemcachedClientProvider @Inject() (configuration: Configuration, lifecycle: ApplicationLifecycle) extends Provider[MemcachedClient] {
+class MemcachedClientProvider @Inject() (config: Config, lifecycle: ApplicationLifecycle) extends Provider[MemcachedClient] {
   lazy val logger = Logger("memcached.plugin")
   lazy val get: MemcachedClient = {
     val client = {
       System.setProperty("net.spy.log.LoggerImpl", "com.github.mumoshu.play2.memcached.Slf4JLogger")
 
-      configuration.getString("elasticache.config.endpoint").map { endpoint =>
-        new MemcachedClient(AddrUtil.getAddresses(endpoint))
-      }.getOrElse {
-        lazy val singleHost = configuration.getString("memcached.host").map(AddrUtil.getAddresses)
-        lazy val consistentHashing = configuration.getBoolean("memcached.consistentHashing").getOrElse(false)
-        lazy val multipleHosts = configuration.getString("memcached.1.host").map { _ =>
+      if(config.hasPath(MemcachedClientProvider.CONFIG_ELASTICACHE_CONFIG_ENDPOINT)) {
+        new MemcachedClient(AddrUtil.getAddresses(config.getString(MemcachedClientProvider.CONFIG_ELASTICACHE_CONFIG_ENDPOINT)))
+      } else {
+        lazy val singleHost = if(config.hasPath(MemcachedClientProvider.CONFIG_HOST)) {
+          Option(AddrUtil.getAddresses(config.getString(MemcachedClientProvider.CONFIG_HOST)))
+        } else {
+          None
+        }
+        lazy val multipleHosts = if(config.hasPath("memcached.1.host")) {
           def accumulate(nb: Int): String = {
-            configuration.getString("memcached." + nb + ".host").map { h => h + " " + accumulate(nb + 1) }.getOrElse("")
+            if(config.hasPath("memcached." + nb + ".host")) {
+              val h = config.getString("memcached." + nb + ".host")
+              h + " " + accumulate(nb + 1)
+            } else {
+              ""
+            }
           }
-          AddrUtil.getAddresses(accumulate(1))
+          Option(AddrUtil.getAddresses(accumulate(1).trim()))
+        } else {
+          None
         }
 
         val addrs = singleHost.orElse(multipleHosts)
           .getOrElse(throw new RuntimeException("Bad configuration for memcached: missing host(s)"))
 
-        configuration.getString("memcached.user").map { memcacheUser =>
-          val memcachePassword = configuration.getString("memcached.password").getOrElse {
+        if(config.hasPath(MemcachedClientProvider.CONFIG_USER)) {
+          val memcacheUser = config.getString(MemcachedClientProvider.CONFIG_USER)
+          val memcachePassword = if(config.hasPath(MemcachedClientProvider.CONFIG_PASSWORD)) {
+            config.getString(MemcachedClientProvider.CONFIG_PASSWORD)
+          } else {
             throw new RuntimeException("Bad configuration for memcached: missing password")
           }
 
           // Use plain SASL to connect to memcached
           val ad = new AuthDescriptor(Array("PLAIN"),
             new PlainCallbackHandler(memcacheUser, memcachePassword))
+          lazy val consistentHashing = config.getBoolean("memcached.consistentHashing")
           val cf = (if (consistentHashing) new ConnectionFactoryBuilder(new KetamaConnectionFactory()) else new ConnectionFactoryBuilder())
             .setProtocol(ConnectionFactoryBuilder.Protocol.BINARY)
-            .setTimeoutExceptionThreshold(configuration.getInt("memcached.max-timeout-exception-threshold").getOrElse(DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD))
+            .setTimeoutExceptionThreshold(
+              if(config.hasPath(MemcachedClientProvider.CONFIG_MAX_TIMEOUT_EXCEPTION_THRESHOLD)) {
+                config.getInt(MemcachedClientProvider.CONFIG_MAX_TIMEOUT_EXCEPTION_THRESHOLD)
+              } else {
+                DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD
+              })
             .setAuthDescriptor(ad)
             .build()
 
           new MemcachedClient(cf, addrs)
-        }.getOrElse {
+        } else {
           new MemcachedClient(addrs)
         }
       }
@@ -62,4 +82,12 @@ class MemcachedClientProvider @Inject() (configuration: Configuration, lifecycle
 
     client
   }
+}
+
+object MemcachedClientProvider {
+  final val CONFIG_ELASTICACHE_CONFIG_ENDPOINT = "elasticache.config.endpoint"
+  final val CONFIG_MAX_TIMEOUT_EXCEPTION_THRESHOLD = "memcached.max-timeout-exception-threshold"
+  final val CONFIG_HOST = "memcached.host"
+  final val CONFIG_USER = "memcached.user"
+  final val CONFIG_PASSWORD = "memcached.password"
 }

--- a/plugin/src/main/com/github/mumoshu/play2/memcached/MemcachedComponents.java
+++ b/plugin/src/main/com/github/mumoshu/play2/memcached/MemcachedComponents.java
@@ -44,13 +44,13 @@ public interface MemcachedComponents extends ConfigurationComponents, AkkaCompon
 
     default MemcachedClientProvider memcachedClientProvider() {
         return new MemcachedClientProvider(
-            configuration(),
+            config(),
             applicationLifecycle().asScala()
         );
     }
 
     default AsyncCacheApi cacheApi(String name) {
-        play.api.cache.AsyncCacheApi scalaAsyncCacheApi = new MemcachedCacheApi(name, memcachedClientProvider().get(), configuration(), environment().asScala(), executionContext());
+        play.api.cache.AsyncCacheApi scalaAsyncCacheApi = new MemcachedCacheApi(name, memcachedClientProvider().get(), config(), environment().asScala(), executionContext());
         return new DefaultAsyncCacheApi(scalaAsyncCacheApi);
     }
 

--- a/plugin/src/main/com/github/mumoshu/play2/memcached/MemcachedModule.scala
+++ b/plugin/src/main/com/github/mumoshu/play2/memcached/MemcachedModule.scala
@@ -2,10 +2,6 @@ package com.github.mumoshu.play2.memcached
 
 import akka.stream.Materializer
 
-import java.util.concurrent.TimeUnit
-
-import net.spy.memcached.transcoders.Transcoder
-import play.api.{Configuration, Environment}
 import play.api.cache._
 import play.api.inject._
 
@@ -42,7 +38,7 @@ class MemcachedModule extends SimpleModule((environment, configuration) => {
     val namedCache = named(name)
     val cacheApiKey = bind[AsyncCacheApi].qualifiedWith(namedCache)
     Seq(
-      cacheApiKey.to(new MemcachedCacheApiProvider(name, bind[MemcachedClient], configuration, environment))
+      cacheApiKey.to(new MemcachedCacheApiProvider(name, bind[MemcachedClient], configuration.underlying, environment))
     ) ++ wrapperBindings(cacheApiKey, namedCache)
   }
 

--- a/plugin/src/main/com/github/mumoshu/play2/memcached/api/MemcachedComponents.scala
+++ b/plugin/src/main/com/github/mumoshu/play2/memcached/api/MemcachedComponents.scala
@@ -1,10 +1,11 @@
 package com.github.mumoshu.play2.memcached.api
 
-import play.api.{ Configuration, Environment }
-import play.api.cache.{ AsyncCacheApi }
+import play.api.Environment
+import play.api.cache.AsyncCacheApi
 import play.api.inject.ApplicationLifecycle
 
 import com.github.mumoshu.play2.memcached.{ MemcachedCacheApi, MemcachedClientProvider }
+import com.typesafe.config.Config
 
 import scala.concurrent.ExecutionContext
 
@@ -12,18 +13,18 @@ import scala.concurrent.ExecutionContext
  * Memcached components for compile time injection
  */
 trait MemcachedComponents {
-  def configuration: Configuration
+  def config: Config
   def environment: Environment
   def applicationLifecycle: ApplicationLifecycle
   implicit def executionContext: ExecutionContext
 
-  lazy val memcachedClientProvider: MemcachedClientProvider = new MemcachedClientProvider(configuration, applicationLifecycle)
+  lazy val memcachedClientProvider: MemcachedClientProvider = new MemcachedClientProvider(config, applicationLifecycle)
 
   /**
    * Use this to create with the given name.
    */
   def cacheApi(name: String, create: Boolean = true): AsyncCacheApi = {
-    new MemcachedCacheApi(name, memcachedClientProvider.get, configuration, environment)
+    new MemcachedCacheApi(name, memcachedClientProvider.get, config, environment)
   }
 
   lazy val defaultCacheApi: AsyncCacheApi = cacheApi("play")

--- a/plugin/src/main/resources/reference.conf
+++ b/plugin/src/main/resources/reference.conf
@@ -14,3 +14,32 @@ play {
   }
 
 }
+
+memcached {
+
+  host = null
+  #1.host = ...
+  #2.host = ...
+
+  user = null
+  password = null
+
+  hashkeys = "off"
+
+  consistentHashing = false
+
+  throwExceptionFromGetOnError = false
+
+  max-timeout-exception-threshold = null
+
+}
+
+elasticache {
+
+  config {
+
+    endpoint = null
+
+  }
+
+}


### PR DESCRIPTION
See https://www.playframework.com/documentation/2.6.x/JavaConfigMigration26#Java-Configuration-API-Migrationmkurz@mkurz-notebook:~/work/play2-memcached

@mumoshu This is my last pull request so far :wink: 